### PR TITLE
recovery: Extract and format EvolutionX version string for recovery t…

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -763,6 +763,23 @@ static void log_failure_code(ErrorCode code, const std::string& update_package) 
   LOG(INFO) << log_content;
 }
 
+std::string getProcessedVersion() {
+    std::string full_version = android::base::GetProperty("ro.evolution.build.version", "(unknown)");
+    std::vector<std::string> parts;
+    std::stringstream ss(full_version);
+    std::string item;
+
+    while (std::getline(ss, item, '-')) {
+        parts.push_back(item);
+    }
+
+    if (parts.size() >= 5) {
+        return parts[0] + "-" + parts[1] + "-" + parts[2] + "-" + parts[4] + "-" + parts[5];
+    } else {
+        return "(unknown)";
+    }
+}
+
 Device::BuiltinAction start_recovery(Device* device, const std::vector<std::string>& args) {
   static constexpr struct option OPTIONS[] = {
     { "fastboot", no_argument, nullptr, 0 },
@@ -890,7 +907,7 @@ Device::BuiltinAction start_recovery(Device* device, const std::vector<std::stri
   std::string ver = android::base::GetProperty("ro.modversion", "");
 
   std::vector<std::string> title_lines = {
-    "Version " + android::base::GetProperty("ro.evolution.build.version", "(unknown)"),
+      "Version " + getProcessedVersion(),
   };
   title_lines.push_back("Product name - " + android::base::GetProperty("ro.product.device", ""));
   if (android::base::GetBoolProperty("ro.build.ab_update", false)) {


### PR DESCRIPTION
…itle

Added a new function `getProcessedVersion` to extract and format the version string from the `ro.evolution.build.version` property. Updated the initialization of `title_lines` to use the formatted version string.

Change-Id: I5fa14554823e6d31dc65f1f43a89b76178e5ec7a